### PR TITLE
Fix installing of extensions in multi-arch prebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,15 +73,9 @@ jobs:
           registry: ${{ env.OPT_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Pull arm
-        run: docker pull ${{ needs.devcontainer-build.outputs.image-arm }}
-      - name: Pull x86
-        run: docker pull ${{ needs.devcontainer-build.outputs.image-x86 }}
-      - name: Create multi-arch manifest
+      - name: Create and push multi-arch image
         run: |
-          docker manifest create \
-            ${{ env.OPT_REGISTRY }}/${{ env.OPT_NAMESPACE }}/${{ env.OPT_IMAGE }}:${{ needs.devcontainer-tag.outputs.tag }} \
-            --amend ${{ needs.devcontainer-build.outputs.image-arm }} \
-            --amend ${{ needs.devcontainer-build.outputs.image-x86 }}
-      - name: Push
-        run: docker manifest push ${{ env.OPT_REGISTRY }}/${{ env.OPT_NAMESPACE }}/${{ env.OPT_IMAGE }}:${{ needs.devcontainer-tag.outputs.tag }}
+          docker buildx imagetools create \
+            --tag ${{ env.OPT_REGISTRY }}/${{ env.OPT_NAMESPACE }}/${{ env.OPT_IMAGE }}:${{ needs.devcontainer-tag.outputs.tag }} \
+            ${{ needs.devcontainer-build.outputs.image-arm }} \
+            ${{ needs.devcontainer-build.outputs.image-x86 }}


### PR DESCRIPTION
Something about swapping `docker manifest create` for `docker buildx imagetools create` brings back the missing metadata.

Additionally;
- No longer have to explicitly pull referenced images.
- Produced multi-arch image is automatically pushed.